### PR TITLE
Don't map ObjC '@' encoding to String (object encoding, not String)

### DIFF
--- a/Sources/MockingbirdFramework/Utilities/ObjCTypeEncodings.swift
+++ b/Sources/MockingbirdFramework/Utilities/ObjCTypeEncodings.swift
@@ -21,5 +21,4 @@ let objCTypeEncodings: [String: ObjectIdentifier] = [
   "B": ObjectIdentifier(CBool.self),
   "v": ObjectIdentifier(Void.self),
   "*": ObjectIdentifier(UnsafePointer<CChar>.self),
-  "@": ObjectIdentifier(String.self),
 ]


### PR DESCRIPTION
## What

The `@` Objective-C type encoding denotes **any object (`id`)**, not `String`. A prior commit mapped `"@": ObjectIdentifier(String.self)` in `objCTypeEncodings`, so `ValueProvider.provideValue(for objcType:)` hands a Swift `String` back for every object-typed ObjC slot. That's incorrect, so this removes the mapping (restoring upstream behavior: object types fall through to `nil` / explicit stubs).

## ⚠️ Note

This was initially suspected to be the cause of an `EXC_BAD_ACCESS` / SIGSEGV under Xcode 26.5 (`-[NSInvocation dealloc]` → `__RELEASE_OBJECTS_IN_THE_ARRAY__`, a use-after-free of a retained invocation argument). **It is NOT** — the crash reproduces unchanged with this fix applied. This PR stands on its own as a correctness fix, but the 26.5 NSInvocation use-after-free is still under investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
