### PR TITLE
Fix object-argument over-release under Xcode 26.5 (drop retainArguments)

### DIFF
--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBObjectInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBObjectInvocationHandler.m
@@ -46,7 +46,13 @@
     [invocation setReturnValue:&nilReturnValue];
     return;
   }
-  
+
+  // `MKBConcreteMock forwardInvocation:` no longer calls `-[NSInvocation
+  // retainArguments]` (it over-releases object arguments under the Xcode 26.5
+  // runtime). `retainArguments` also used to keep the return value alive past
+  // `forwardInvocation:`; preserve that here by retaining + autoreleasing the
+  // value so it outlives this call frame and the caller can take ownership.
+  CFAutorelease(CFBridgingRetain(returnValue));
   [invocation setReturnValue:&returnValue];
 }
 

--- a/Sources/MockingbirdFramework/Objective-C/MKBConcreteMock.m
+++ b/Sources/MockingbirdFramework/Objective-C/MKBConcreteMock.m
@@ -36,8 +36,21 @@
 
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
-  // Ensure that the argument and return value lifetimes are long enough.
-  [invocation retainArguments];
+  // NOTE: We intentionally do NOT call `-[NSInvocation retainArguments]` here.
+  //
+  // `retainArguments` makes this (runtime-owned, autoreleased) invocation retain
+  // every object argument and release them when it deallocs — which happens much
+  // later, when the enclosing autorelease pool drains. Under the Xcode 26.5 ObjC
+  // runtime that deferred release races with / over-releases object arguments
+  // (e.g. a UIViewController passed to a mocked method), producing an
+  // EXC_BAD_ACCESS in `-[NSInvocation dealloc]` -> `__RELEASE_OBJECTS_IN_THE_ARRAY__`.
+  //
+  // We don't need it: arguments are serialized synchronously below into
+  // `MKBArgumentMatcher`s (which retain what they need) while the caller's frame
+  // still holds the arguments alive. The only other thing `retainArguments`
+  // guarded was the return value's lifetime, which we now handle explicitly in
+  // `-deserializeReturnValue:forInvocation:` by autoreleasing the value before
+  // setting it on the invocation.
 
   NSString *selectorName = NSStringFromSelector(invocation.selector);
   NSMutableArray<MKBArgumentMatcher *> *arguments = [[NSMutableArray alloc] init];


### PR DESCRIPTION
## Problem

Under the **Xcode 26.5** ObjC runtime, running the fabulous-ios test suite crashes with `EXC_BAD_ACCESS` / SIGSEGV:

```text
objc_release
__RELEASE_OBJECTS_IN_THE_ARRAY__
-[__NSArrayM dealloc]
-[NSInvocation dealloc]
objc_autoreleasePoolPop
```

`MKBConcreteMock forwardInvocation:` calls `-[NSInvocation retainArguments]`. That makes the **runtime-owned, autoreleased** invocation retain every object argument and release them when it deallocs — which happens later, when the enclosing autorelease pool drains. Under 26.5 that deferred release **over-releases** object arguments. Confirmed via `NSZombieEnabled`:

```text
*** -[FabulousCommon.ChallengeListViewController release]: message sent to deallocated instance
```

(A `ChallengeListViewController` passed to a mocked `attachView(with:)`.) Tolerated under Xcode 26.0; fatal under 26.5. The crash surfaces cross-test (the bad invocation drains during a later test), which made it look flaky.

## Fix

Don't call `retainArguments`. Arguments are serialized **synchronously** into `MKBArgumentMatcher`s (which retain what they need) while the caller's frame still holds them, so the invocation doesn't need to retain them. The only other thing `retainArguments` guarded was **return-value lifetime**, now handled explicitly by retaining + autoreleasing the value in `MKBObjectInvocationHandler` before `setReturnValue:`.

## Verification

fabulous-ios full test suite on Xcode 26.5 / iPhone 17 Pro:
- Before: deterministic SIGSEGV (1 crash / 2331 pass).
- After: **all bundles pass, exit 0**, no crash/zombie/restart — verified both serially (the reliable repro) and in the parallel CI plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object lifetime management in the mocking framework to ensure object arguments and return values remain valid after invocation completion.

* **Refactor**
  * Updated internal invocation handling to explicitly manage object serialization and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->